### PR TITLE
Replace 'zombie' with 'inactive' in CCSupply.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ address_tx/
 cardBalances/
 Etherscan_API_Key.txt
 The_Graph_API_Key.txt
-Zombie_Addresses.txt
+Inactive_Addresses.txt
 *.csv
 *.json
 


### PR DESCRIPTION
The terms "zombie" and "inactive" are used interchangeably, which can be confusing. To be consistent between the Python code and the website, this pull request replaces all instances of "zombie" with "inactive" in CCSupply.py, including replacing the output file name "Zombie_Addresses.txt" with "Inactive_Addresses.txt".